### PR TITLE
Pure python testing library

### DIFF
--- a/testing_lang/testing_language.py
+++ b/testing_lang/testing_language.py
@@ -64,8 +64,8 @@ class TestingLanguage(object):
         return len(self.transactions) - 1
 
     def transfer(self,
-                 input1, newowner1, amount1, key1,
-                 input2=None, newowner2=None, amount2=None, key2=None):
+                 input1, newowner1, amount1, signatory1,
+                 input2=None, newowner2=None, amount2=None, signatory2=None):
         newowner_address1 = newowner1['address']
         amount1 = int(amount1)
 
@@ -93,9 +93,11 @@ class TestingLanguage(object):
                          newowner_address1, amount1,
                          newowner_address2, amount2)
 
+        key1 = signatory1['key']
         tx.sign1(key1)
 
         if input2 is not None:
+            key2 = signatory2['key']
             tx.sign2(key2)
 
         encoded_tx = rlp.encode(tx).hex()

--- a/tests/child_chain/test_child_chain.py
+++ b/tests/child_chain/test_child_chain.py
@@ -64,7 +64,6 @@ def test_send_tx_double_spend(test_lang):
     # given
     owner_1 = test_lang.get_account()
     owner_2 = test_lang.get_account()
-    owner_3 = test_lang.get_account()
 
     deposit_id = test_lang.deposit(owner_1, 100)
     test_lang.transfer(deposit_id, owner_2, 100, owner_1)

--- a/tests/child_chain/test_child_chain.py
+++ b/tests/child_chain/test_child_chain.py
@@ -9,7 +9,7 @@ def test_apply_deposit(test_lang):
     owner = test_lang.get_account()
 
     # when
-    deposit_id = test_lang.deposit(owner, 100)
+    test_lang.deposit(owner, 100)
 
     # then
     deposit_block_number = 1
@@ -21,11 +21,10 @@ def test_send_tx_with_sig(test_lang):
     # given
     owner_1 = test_lang.get_account()
     owner_2 = test_lang.get_account()
-    key = owner_1['key']
 
     # when
     deposit_id = test_lang.deposit(owner_1, 100)
-    test_lang.transfer(deposit_id, owner_2, 100, key)
+    test_lang.transfer(deposit_id, owner_2, 100, owner_1)
 
     # then
     # XXX - assert something?
@@ -49,27 +48,31 @@ def test_send_tx_with_sig(test_lang):
 
 
 def test_send_tx_invalid_sig(test_lang):
+    # given
     owner_1 = test_lang.get_account()
     owner_2 = test_lang.get_account()
-    key = test_lang.get_account()['key']
+    owner_3 = test_lang.get_account()
 
     deposit_id = test_lang.deposit(owner_1, 100)
 
+    # when/then
     with pytest.raises(InvalidTxSignatureException):
-        test_lang.transfer(deposit_id, owner_2, 100, key)
+        test_lang.transfer(deposit_id, owner_2, 100, owner_3)
 
 
 def test_send_tx_double_spend(test_lang):
+    # given
     owner_1 = test_lang.get_account()
     owner_2 = test_lang.get_account()
-    key = owner_1['key']
+    owner_3 = test_lang.get_account()
 
     deposit_id = test_lang.deposit(owner_1, 100)
-    test_lang.transfer(deposit_id, owner_2, 100, key)
+    test_lang.transfer(deposit_id, owner_2, 100, owner_1)
 
+    # when/then
     with pytest.raises(TxAlreadySpentException):
         # Try to submit again
-        test_lang.transfer(deposit_id, owner_2, 100, key)
+        test_lang.transfer(deposit_id, owner_2, 100, owner_1)
 
 
 def test_submit_block(test_lang):

--- a/tests/child_chain/test_child_chain.py
+++ b/tests/child_chain/test_child_chain.py
@@ -5,60 +5,71 @@ from plasma.child_chain.exceptions import (InvalidBlockSignatureException,
 
 
 def test_apply_deposit(test_lang):
-    test_lang_string = '''
-        Deposit1[Owner1,100]
-    '''
+    # given
+    owner = test_lang.get_account()
 
-    test_lang.parse(test_lang_string)
+    # when
+    deposit_id = test_lang.deposit(owner, 100)
+
+    # then
     deposit_block_number = 1
     deposit_block = test_lang.child_chain.blocks[deposit_block_number]
     assert len(deposit_block.transaction_set) == 1
 
 
 def test_send_tx_with_sig(test_lang):
-    test_lang_string = '''
-        Deposit1[Owner1,100]
-        Transfer1[Deposit1,Owner2,100,Owner1]
-    '''
+    # given
+    owner_1 = test_lang.get_account()
+    owner_2 = test_lang.get_account()
+    key = owner_1['key']
 
-    test_lang.parse(test_lang_string)
+    # when
+    deposit_id = test_lang.deposit(owner_1, 100)
+    test_lang.transfer(deposit_id, owner_2, 100, key)
+
+    # then
+    # XXX - assert something?
 
 
-def test_send_tx_no_sig(test_lang):
-    test_lang_string = '''
-        Deposit1[Owner1,100]
-        Transfer1[Deposit1,Owner2,100]
-    '''
-
-    with pytest.raises(InvalidTxSignatureException):
-        test_lang.parse(test_lang_string)
+# XXX - redundant test – tests the same behavior as `test_send_tx_invalid_sig`
+# def test_send_tx_no_sig(test_lang):
+#     # test_lang_string = '''
+#     #     Deposit1[Owner1,100]
+#     #     Transfer1[Deposit1,Owner2,100,null,null,null,null,null]
+#     # '''
+#
+#     owner_1 = test_lang.get_account()
+#     owner_2 = test_lang.get_account()
+#     key = None
+#
+#     deposit_id = test_lang.deposit(owner_1, 100)
+#
+#     with pytest.raises(InvalidTxSignatureException):
+#         test_lang.transfer(deposit_id, owner_2, 100, key)
 
 
 def test_send_tx_invalid_sig(test_lang):
-    test_lang_string = '''
-        Deposit1[Owner1,100]
-        Transfer1[Deposit1,Owner2,100,Owner3]
-    '''
+    owner_1 = test_lang.get_account()
+    owner_2 = test_lang.get_account()
+    key = test_lang.get_account()['key']
+
+    deposit_id = test_lang.deposit(owner_1, 100)
 
     with pytest.raises(InvalidTxSignatureException):
-        test_lang.parse(test_lang_string)
+        test_lang.transfer(deposit_id, owner_2, 100, key)
 
 
 def test_send_tx_double_spend(test_lang):
-    test_lang_string1 = '''
-        Deposit1[Owner1,100]
-        Transfer1[Deposit1,Owner2,100,Owner1]
-    '''
+    owner_1 = test_lang.get_account()
+    owner_2 = test_lang.get_account()
+    key = owner_1['key']
 
-    test_lang_string2 = '''
-        Transfer2[Deposit1,Owner2,100,Owner1]
-    '''
+    deposit_id = test_lang.deposit(owner_1, 100)
+    test_lang.transfer(deposit_id, owner_2, 100, key)
 
-    test_lang.parse(test_lang_string1)
-
-    # Try to submit again
     with pytest.raises(TxAlreadySpentException):
-        test_lang.parse(test_lang_string2)
+        # Try to submit again
+        test_lang.transfer(deposit_id, owner_2, 100, key)
 
 
 def test_submit_block(test_lang):


### PR DESCRIPTION
This the beginning of what I mean by a pure python testing library. Pay less attention to the implementation and more to how it reads in the tests.

It keeps the same semantics as your DSL. It's a slightly longer because we're keeping less implicit state (account and transaction identifiers for now).  Ideally, I'd like to take all the state out of the library and make it purely functional.

- I find it easier to follow because behavior is more explicit. It's more what I'd expect in a domain specific testing library.
- No implicit account creation. It would be nice if addresses and keys were generated rather than hard coded, if that's possible in a performant way.
- Even thought it's more verbose since we're pulling some state out, each line has meaning in the context of the domain being tested, rather than seeing `test_lang.parse` all over.
- It's less cognitive load since you don't have to switch between the DSL for test setup and then back to python to assert behavior.
- We could rename `testing_lang` to something fun like `ion`, `phaser`, or something else kind of plasma/physics related

I know this is less ambitious than what you were going for but I would find it easier to understand coming from the outside the project and it will be easier to maintain/extend.  If you like it, I can also flow the changes through all the tests.
